### PR TITLE
Explicit assignment operators for Observation, default assignment is …

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/observation.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/observation.hpp
@@ -60,9 +60,18 @@ public:
   }
 
   /**
-    * @brief  Explicitly define copy assignment operator for Observation as it has a user-declared destructor
-    */
-  Observation & operator=(const Observation &) = default;
+   * @brief  Copy assignment operator
+   * @param obs The observation to copy
+   */
+  Observation & operator=(const Observation & obs)
+  {
+    origin_ = obs.origin_;
+    cloud_ = new sensor_msgs::msg::PointCloud2(*(obs.cloud_));
+    obstacle_range_ = obs.obstacle_range_;
+    raytrace_range_ = obs.raytrace_range_;
+
+    return *this;
+  }
 
   /**
    * @brief  Creates an observation from an origin point and a point cloud


### PR DESCRIPTION
…a bug here (#2413)

* Explicit assignment operators for Observation

Also move constructor. Default copy assignment is not just a shortcut to copy constructor, sadly

* uncrustified and removed not bug-related stuff

* style fix

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
